### PR TITLE
[fix] login UI translation

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -55,7 +55,7 @@
 {% macro logo_section() %}
 <div class="page-card-head">
 	<img class="app-logo" src="{{ logo }}">
-	<h4>{{ _('Login to {0}').format(app_name or _("Frappe")) }}</h4>
+	<h4>{{ _('Login to {0}'.format(app_name or _("Frappe"))) }}</h4>
 </div>
 {% endmacro %}
 

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -133,7 +133,7 @@ def send_login_link(email: str):
 		frappe.get_website_settings("app_name") or frappe.get_system_settings("app_name") or _("Frappe")
 	)
 
-	subject = _("Login To {0}").format(app_name)
+	subject = _("Login To {0}".format(app_name))
 
 	frappe.sendmail(
 		subject=subject,


### PR DESCRIPTION
The "Login to ERPNext" is not able to be translated due to a coding defect in the existing frappe code.
<img width="682" alt="image" src="https://github.com/shengchu/frappe/assets/16083557/b2a297b5-78b1-4fb4-a235-0bee9fe26835">


